### PR TITLE
link DOIs against preferred resolver

### DIFF
--- a/rcrossref/crossrefFun.R
+++ b/rcrossref/crossrefFun.R
@@ -121,7 +121,7 @@ simpleCap <- function(x) {
 getCrossrefMeta = function(doi, author)
 {
   if(!grepl('^http', doi))
-    doi = paste0("http://dx.doi.org/", doi)
+    doi = paste0("https://doi.org/", doi)
   page = try(htmlParse(doi), TRUE)
   if("try-error" %in% attr(page, "class"))
     return(NA)


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). If I understood your code correctly, it generated links / URLs from the DOIs, correct? If yes, please consider integrating this change, see diff.

Cheers :-)